### PR TITLE
imagettftextblur v1.2.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # imagettftextblur
 
+[![MIT License](https://img.shields.io/github/license/andrewgjohnson/imagettftextblur.svg)](https://github.com/andrewgjohnson/imagettftextblur/blob/master/LICENSE)
+[![Current Release](https://img.shields.io/github/release/andrewgjohnson/imagettftextblur.svg)](https://github.com/andrewgjohnson/imagettftextblur/releases)
+[![GitHub Stars](https://img.shields.io/github/stars/andrewgjohnson/imagettftextblur.svg)](https://github.com/andrewgjohnson/imagettftextblur/stargazers)
+[![Contributors](https://img.shields.io/github/contributors/andrewgjohnson/imagettftextblur.svg)](https://github.com/andrewgjohnson/imagettftextblur/graphs/contributors)
+[![Packagist Downloads](https://img.shields.io/packagist/dm/andrewgjohnson/imagettftextblur.svg)](https://packagist.org/packages/andrewgjohnson/imagettftextblur/stats)
+[![Issues](https://img.shields.io/github/issues/andrewgjohnson/imagettftextblur.svg)](https://github.com/andrewgjohnson/imagettftextblur/issues)
+
 ## Description
 
 imagettftextblur is a drop in replacement for imagettftext with added parameters to add blur, glow and shadow effects to your PHP GD images.
@@ -43,6 +50,11 @@ Full list of contributors:
  * [Philip van Heemstra (@vHeemstra)](https://github.com/vHeemstra)
 
 ## Changelog
+
+###### v1.2.11 (March 8, 2018)
+ * Added [shields.io badges](http://shields.io/) to README.md
+ * Updated link to MIT license on opensource.org
+ * Updated the "2017" copyright references to "2018"
 
 ###### v1.2.10 (June 23, 2017)
  * Updated StackOverflow link in README.md

--- a/examples/example_glow.php
+++ b/examples/example_glow.php
@@ -3,7 +3,7 @@
 /**
  * Imagettftextblur Example (Glow)
  *
- * Copyright (c) 2013-2017 Andrew G. Johnson <andrew@andrewgjohnson.com>
+ * Copyright (c) 2013-2018 Andrew G. Johnson <andrew@andrewgjohnson.com>
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in the
  * Software without restriction, including without limitation the rights to use,
@@ -24,8 +24,8 @@
  * @category  Andrewgjohnson
  * @package   Imagettftextblur
  * @author    Andrew G. Johnson <andrew@andrewgjohnson.com>
- * @copyright 2013-2017 Andrew G. Johnson <andrew@andrewgjohnson.com>
- * @license   http://www.opensource.org/licenses/mit-license.php The MIT License
+ * @copyright 2013-2018 Andrew G. Johnson <andrew@andrewgjohnson.com>
+ * @license   https://opensource.org/licenses/mit/ The MIT License
  * @link      http://github.com/andrewgjohnson/imagettftextblur
  */
 

--- a/examples/example_shadow.php
+++ b/examples/example_shadow.php
@@ -3,7 +3,7 @@
 /**
  * Imagettftextblur Example (Shadow)
  *
- * Copyright (c) 2013-2017 Andrew G. Johnson <andrew@andrewgjohnson.com>
+ * Copyright (c) 2013-2018 Andrew G. Johnson <andrew@andrewgjohnson.com>
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in the
  * Software without restriction, including without limitation the rights to use,
@@ -24,8 +24,8 @@
  * @category  Andrewgjohnson
  * @package   Imagettftextblur
  * @author    Andrew G. Johnson <andrew@andrewgjohnson.com>
- * @copyright 2013-2017 Andrew G. Johnson <andrew@andrewgjohnson.com>
- * @license   http://www.opensource.org/licenses/mit-license.php The MIT License
+ * @copyright 2013-2018 Andrew G. Johnson <andrew@andrewgjohnson.com>
+ * @license   https://opensource.org/licenses/mit/ The MIT License
  * @link      http://github.com/andrewgjohnson/imagettftextblur
  */
 

--- a/examples/example_with-blur.php
+++ b/examples/example_with-blur.php
@@ -3,7 +3,7 @@
 /**
  * Imagettftextblur Example (With Blur)
  *
- * Copyright (c) 2013-2017 Andrew G. Johnson <andrew@andrewgjohnson.com>
+ * Copyright (c) 2013-2018 Andrew G. Johnson <andrew@andrewgjohnson.com>
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in the
  * Software without restriction, including without limitation the rights to use,
@@ -24,8 +24,8 @@
  * @category  Andrewgjohnson
  * @package   Imagettftextblur
  * @author    Andrew G. Johnson <andrew@andrewgjohnson.com>
- * @copyright 2013-2017 Andrew G. Johnson <andrew@andrewgjohnson.com>
- * @license   http://www.opensource.org/licenses/mit-license.php The MIT License
+ * @copyright 2013-2018 Andrew G. Johnson <andrew@andrewgjohnson.com>
+ * @license   https://opensource.org/licenses/mit/ The MIT License
  * @link      http://github.com/andrewgjohnson/imagettftextblur
  */
 

--- a/examples/example_without-blur.php
+++ b/examples/example_without-blur.php
@@ -3,7 +3,7 @@
 /**
  * Imagettftextblur Example (Without Blur)
  *
- * Copyright (c) 2013-2017 Andrew G. Johnson <andrew@andrewgjohnson.com>
+ * Copyright (c) 2013-2018 Andrew G. Johnson <andrew@andrewgjohnson.com>
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in the
  * Software without restriction, including without limitation the rights to use,
@@ -24,8 +24,8 @@
  * @category  Andrewgjohnson
  * @package   Imagettftextblur
  * @author    Andrew G. Johnson <andrew@andrewgjohnson.com>
- * @copyright 2013-2017 Andrew G. Johnson <andrew@andrewgjohnson.com>
- * @license   http://www.opensource.org/licenses/mit-license.php The MIT License
+ * @copyright 2013-2018 Andrew G. Johnson <andrew@andrewgjohnson.com>
+ * @license   https://opensource.org/licenses/mit/ The MIT License
  * @link      http://github.com/andrewgjohnson/imagettftextblur
  */
 

--- a/source/imagettftextblur.php
+++ b/source/imagettftextblur.php
@@ -1,9 +1,9 @@
 <?php
 
 /**
- * Imagettftextblur v1.2.10
+ * Imagettftextblur v1.2.11
  *
- * Copyright (c) 2013-2017 Andrew G. Johnson <andrew@andrewgjohnson.com>
+ * Copyright (c) 2013-2018 Andrew G. Johnson <andrew@andrewgjohnson.com>
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in the
  * Software without restriction, including without limitation the rights to use,
@@ -24,8 +24,8 @@
  * @category  Andrewgjohnson
  * @package   Imagettftextblur
  * @author    Andrew G. Johnson <andrew@andrewgjohnson.com>
- * @copyright 2013-2017 Andrew G. Johnson <andrew@andrewgjohnson.com>
- * @license   http://www.opensource.org/licenses/mit-license.php The MIT License
+ * @copyright 2013-2018 Andrew G. Johnson <andrew@andrewgjohnson.com>
+ * @license   https://opensource.org/licenses/mit/ The MIT License
  * @link      http://github.com/andrewgjohnson/imagettftextblur
  */
 


### PR DESCRIPTION
v1.2.11 (March 8, 2018)
 * Added shields.io badges to README.md
 * Updated link to MIT license on opensource.org
 * Updated the "2017" copyright references to "2018"